### PR TITLE
Update Dockerfile, don't replace quote characters in attributes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM golang:alpine
+FROM golang:alpine AS build
 RUN mkdir /app
 ADD . /app/
 WORKDIR /app
-RUN apk add --no-cache git \
-    && go get github.com/gomodule/redigo/redis \
-    && go build -o main .
+RUN apk add --no-cache git
+RUN go get github.com/gomodule/redigo/redis
+RUN go build -o main .
+
+FROM alpine:latest
+COPY --from=build /app/main .
 EXPOSE 8125
 CMD ["./main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:alpine
 RUN mkdir /app
 ADD . /app/
 WORKDIR /app
-RUN apk add --no-cache git mercurial \
+RUN apk add --no-cache git \
     && go get github.com/gomodule/redigo/redis \
     && go build -o main .
 EXPOSE 8125

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
-FROM alpine:latest
-RUN apk update && apk upgrade
-COPY build/linux-amd64/bin/samplesvc /usr/local/bin/
-EXPOSE 8081
-ENTRYPOINT ["/usr/local/bin/samplesvc"]
+FROM golang:alpine
+RUN mkdir /app
+ADD . /app/
+WORKDIR /app
+RUN apk add --no-cache git mercurial \
+    && go get github.com/gomodule/redigo/redis \
+    && go build -o main .
+EXPOSE 8125
+CMD ["./main"]

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ type sampleLink struct {
 func main() {
 	port, overridden := os.LookupEnv("PORT")
 	if !overridden {
-		port = ":8081"
+		port = ":8125"
 	}
 
 	redisPool := redis.NewPool(func() (redis.Conn, error) {

--- a/main.go
+++ b/main.go
@@ -34,11 +34,6 @@ type info struct {
 	Built   string `json:"built"`
 }
 
-type sampleLink struct {
-	CollectionExerciseID string `json:"collectionExerciseId"`
-	SampleSummaryID      string `json:"sampleSummaryId"`
-}
-
 func main() {
 	port, overridden := os.LookupEnv("PORT")
 	if !overridden {
@@ -79,14 +74,14 @@ func main() {
 
 		if err != nil {
 			w.WriteHeader(404)
-			fmt.Println(err)
+			fmt.Println("ERROR: " + err.Error() + ", Sampleunit id: " + id)
 			message := fmt.Sprintf("Could not GET %s", id)
 			fmt.Fprintf(w, "%s\n", message)
 		} else {
 			w.Header().Set(contentType, jsonUTF8)
 			fmt.Fprintf(w, "%s\n", value)
 		}
-	
+
 	})
 	log.Fatal(http.ListenAndServe(port, nil))
 }

--- a/main.go
+++ b/main.go
@@ -83,12 +83,10 @@ func main() {
 			message := fmt.Sprintf("Could not GET %s", id)
 			fmt.Fprintf(w, "%s\n", message)
 		} else {
-			// have to swap ' for " as its a python object written and ' is not valid JSON
 			w.Header().Set(contentType, jsonUTF8)
-			value = strings.Replace(value, "'", "\"", -1)
 			fmt.Fprintf(w, "%s\n", value)
 		}
-
+	
 	})
 	log.Fatal(http.ListenAndServe(port, nil))
 }


### PR DESCRIPTION
### Motivation and Context
The dockerfile needed updating to run the app in kubernetes and removing the replacement of quote characters corresponding to https://github.com/ONSdigital/census-rm-sample-loader/pull/1.

### What has Changed 
- Rewritten Dockerfile
- Changed the default port to the same as the ras-rm-docker-dev sample service to avoid conflicting locally
- Remove the replacement of quote characters in sample attributes
- Add sample unit ID to the error print

### How to Test
Run a sample load with the sample loader branch, this service should still return valid JSON from it's sample attributes end point.

### Links
https://trello.com/c/RNdmBBDk/454-handle-apostrophes-in-catd-sample-load-process
https://github.com/ONSdigital/census-rm-sample-loader/pull/1