### PR TITLE
Execute the Sample service stub under a dedicated non-root user account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ RUN go get github.com/gomodule/redigo/redis
 RUN go build -o main .
 
 FROM alpine:latest
+RUN addgroup -g 996 samplesvc && \
+    adduser -u 996 -S samplesvc -G samplesvc
+USER samplesvc
 COPY --from=build /app/main .
 EXPOSE 8125
-CMD ["./main"]
+ENTRYPOINT ["./main"]


### PR DESCRIPTION
# Motivation and Context
The principle of using least privilege should be followed when executing code within containers. Specifically, not running as root.

# What has changed
The Dockerfile has been changed:

* Create a dedicated non-root user account for executing the Go code
* `ENTRYPOINT` should be preferred to `CMD` because the previous use of `CMD` prevented `exec`-ing into the container with an error about `./main` not being in the path

# How to test?
I tested this change by creating a differently tagged Docker image and deploying to my Kubernetes cluster. I verified that:

* The pod started successfully
* The Kubernetes readiness and liveness probes succeeded
* There were no errors in the container logs
* `exec`-ing into the container showed the Go process running as the expected non-root user account